### PR TITLE
(almost) one-pass debuggable object creation

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -1606,7 +1606,7 @@ Object.subclass('Squeak.Object',
                     name = prop.value;
                     if (name.format >= 8 && name.format < 12) {
                         if (name.bytes)
-                            return Squeak.bytesAsString(name.bytes);
+                            return Squeak.bytesAsString(name.bytes) + " class";
                         var bytes = this.decodeBytes(name.bits.length, name.bits, 0, name.format & 3);
                         return Squeak.bytesAsString(bytes) + " class";
                     }

--- a/vm.js
+++ b/vm.js
@@ -999,7 +999,11 @@ Object.subclass('Squeak.Image',
                                 var nameOop = thisClass.bits[Squeak.Class_name];
                                 var name = oopMap[nameOop];
                                 if (name.format >= 8 && name.format < 12) {
-                                    var bytes = classObj.decodeBytes(name.bits.length, name.bits, 0, name.format & 3);
+                                    var bytes;
+                                    if (name.bytes)
+                                        bytes = name.bytes;
+                                    else
+                                        bytes = classObj.decodeBytes(name.bits.length, name.bits, 0, name.format & 3);
                                     instConstructor = new Function("return function " + Squeak.bytesAsString(bytes) + "_class() {};")();
                                     instConstructor.prototype = Squeak.Object.prototype;
                                     object = new instConstructor;

--- a/vm.js
+++ b/vm.js
@@ -926,7 +926,7 @@ Object.subclass('Squeak.Image',
                     if (!compactClasses && (oldOop === compactClassesOop)) {
                         compactClasses = bits;
                     }
-                    classObj = oopMap[compactClasses[classInt - 1]];
+                    classObj = oopMap[classInt = compactClasses[classInt - 1]];
                     hash |= 0x10000000;
                 } else
                     classObj = oopMap[classInt];


### PR DESCRIPTION
Instead of creating the objects and then recreating them, I created them as "proxies" (self-replacing get properties). In order to get the next pointers right I had to then reverse the traversal order for hydrating the proxies/objects.
I also did a more thorough job with the debuggable names (e.g. symbol literals, classes, metaclasses).
I replaced the names instProto and classInstProto with instConstructor and classInstConstructor, I think it more accurately reflects reality and my head hurt when I was debugging the metaclasses cycles and looking at protos and instProtos :)