### PR TITLE
Typo in primitiveCopyObject... receiver and argument are swapped…

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -4578,7 +4578,7 @@ Object.subclass('Squeak.Primitives',
             rcvr.sqClass !== arg.sqClass ||
             length !== arg.pointersSize()) return false;
         for (var i = 0; i < length; i++)
-            arg.pointers[i] = rcvr.pointers[i];
+            rcvr.pointers[i] = arg.pointers[i];
         this.vm.pop(argCount);
         return true;
     },


### PR DESCRIPTION
…when doing the copy. I noticed this when I tried to "safely" remove a method from a method dictionary and it was still there. :)