### PR TITLE
Add functional name/address resolver to SocketPlugin

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -5082,6 +5082,12 @@ Object.subclass('Squeak.Primitives',
             array.pointers[i] = this.makeStObject(jsArray[i], proxyClass);
         return array;
     },
+    makeStByteArray: function(jsArray) {
+        var array = this.vm.instantiateClass(this.vm.specialObjects[Squeak.splOb_ClassByteArray], jsArray.length);
+        for (var i = 0; i < jsArray.length; i++)
+            array.bytes[i] = jsArray[i] & 0xff;
+        return array;
+    },
     makeStString: function(jsString) {
         var stString = this.vm.instantiateClass(this.vm.specialObjects[Squeak.splOb_ClassString], jsString.length);
         for (var i = 0; i < jsString.length; ++i)


### PR DESCRIPTION
With this functionality it is possible to either lookup the (IPv4) address of the given hostname or lookup the name of the given address.

For address lookup DNS over HTTP (DoH) is used. For name lookup the cached name (from the address lookup) is used. There are some API's for doing name lookups, but these are not standardised like DoH and/or require a payed subscription. Therefore chosen for simple solution assuming lookups are always done for addresses resolved earlier in the process. If an unknown address is provided, the dotted decimal name is answered (ie `'104.24.23.6'`).

Quad9 (IP 9.9.9.9) is used as server for DoH because it seems to take privacy of users serious. Other servers can be found at https://en.wikipedia.org/wiki/Public_recursive_name_server

Example (tested on Cuis and Squeak):
```Smalltalk
| address name |
address := NetNameResolver addressForName: 'squeak.js.org'.
name := NetNameResolver nameForAddress: address timeout: 5.
{ address . name } "Array with: #[104 24 23 6] with: 'squeak.js.org'"
```