### PR TITLE
fix bug in primitivePerformWithArgs

### DIFF
--- a/vm.js
+++ b/vm.js
@@ -3584,7 +3584,14 @@ Object.subclass('Squeak.Interpreter',
         }
         var trueArgCount = args.pointersSize();
         var stack = this.activeContext.pointers;
-        this.arrayCopy(args.pointers, 0, stack, this.sp - 1, trueArgCount);
+        var startingStackPositionOfArguments;
+
+	if (supered)
+	  startingStackPositionOfArguments = this.sp - 2;
+	else
+	  startingStackPositionOfArguments = this.sp -1;
+		      
+	this.arrayCopy(args.pointers, 0, stack, startingStackPositionOfArguments, trueArgCount);
         this.sp += trueArgCount - argCount; //pop selector and array then push args
         var entry = this.findSelectorInClass(selector, trueArgCount, lookupClass);
         this.executeNewMethod(rcvr, entry.method, entry.argCount, entry.primIndex, entry.mClass, selector);

--- a/vm.js
+++ b/vm.js
@@ -3589,7 +3589,7 @@ Object.subclass('Squeak.Interpreter',
 	if (supered)
 	  startingStackPositionOfArguments = this.sp - 2;
 	else
-	  startingStackPositionOfArguments = this.sp -1;
+	  startingStackPositionOfArguments = this.sp - 1;
 		      
 	this.arrayCopy(args.pointers, 0, stack, startingStackPositionOfArguments, trueArgCount);
         this.sp += trueArgCount - argCount; //pop selector and array then push args


### PR DESCRIPTION
When "supered", arguments were copied to the wrong place in the stack, and the stack pointer was set incorrectly. Squeak doesn't use this feature much, but Pharo does.